### PR TITLE
🧪 [testing improvement] JSON-LD parsing error path test

### DIFF
--- a/content.js
+++ b/content.js
@@ -256,3 +256,11 @@ async function displayTimestamp(pubDate, pubSource, modDate, modSource, overlayE
         }, 500);
     }, 5000);
 }
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        formatDate,
+        findStructuredData,
+        processStructuredData
+    };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "last-modified-timestamp",
+  "version": "1.0.2",
+  "description": "Chrome extension to find the most reliable published and last modified timestamps of any webpage.",
+  "main": "background.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^30.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrandonML/last-modified-chrome-extension.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/BrandonML/last-modified-chrome-extension/issues"
+  },
+  "homepage": "https://github.com/BrandonML/last-modified-chrome-extension#readme"
+}

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,0 +1,66 @@
+// Mock globals before requiring content.js
+global.window = {};
+global.document = {
+    querySelectorAll: jest.fn()
+};
+global.chrome = {
+    storage: {
+        sync: {
+            get: jest.fn()
+        }
+    },
+    runtime: {
+        sendMessage: jest.fn()
+    }
+};
+
+const { findStructuredData, processStructuredData } = require('../content');
+
+describe('findStructuredData error handling', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+        document.querySelectorAll.mockReset();
+        chrome.storage.sync.get.mockReset();
+        chrome.runtime.sendMessage.mockReset();
+    });
+
+    test('should catch and log error when JSON.parse fails', () => {
+        const mockScript = {
+            textContent: 'invalid json'
+        };
+        document.querySelectorAll.mockReturnValue([mockScript]);
+
+        const results = findStructuredData();
+
+        expect(results).toBeNull();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Error parsing structured data:',
+            expect.any(Error)
+        );
+    });
+
+    test('should continue processing other scripts when one fails', () => {
+        const invalidScript = {
+            textContent: 'invalid json'
+        };
+        const validScript = {
+            textContent: JSON.stringify({
+                '@type': 'Article',
+                'datePublished': '2023-01-01'
+            })
+        };
+        document.querySelectorAll.mockReturnValue([invalidScript, validScript]);
+
+        const results = findStructuredData();
+
+        expect(results).not.toBeNull();
+        expect(results.published).toBe('2023-01-01');
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
This PR addresses the missing error path test for JSON-LD parsing in `content.js`. Previously, the `try-catch` block around `JSON.parse` was not explicitly tested, meaning regressions in error handling might not be caught.

### 📊 Coverage: What scenarios are now tested
- **Invalid JSON-LD Parsing**: Verified that if a script tag contains malformed JSON, the error is caught, logged to the console, and doesn't crash the script.
- **Resilience**: Verified that if one JSON-LD script is malformed, the extension continues to process other valid script tags on the page.

### ✨ Result: The improvement in test coverage
- Added automated unit tests using Jest.
- Improved the testability of `content.js` by adding conditional exports.
- Established a testing foundation for the project with a configured `package.json` and `tests/` directory.

---
*PR created automatically by Jules for task [10168025722982266904](https://jules.google.com/task/10168025722982266904) started by @BrandonML*