### PR TITLE
🔒 [security fix] Sanitize URLs in console logs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,20 @@
 // background.js - Background service worker
+
+/**
+ * Sanitizes a URL by removing query parameters and fragments to prevent sensitive data exposure.
+ * @param {string} url The URL to sanitize.
+ * @returns {string} The sanitized URL.
+ */
+function sanitizeUrl(url) {
+    if (!url) return '';
+    try {
+        const parsed = new URL(url);
+        return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+    } catch (e) {
+        return '[INVALID URL]';
+    }
+}
+
 // Open onboarding page on install
 chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === 'install') {
@@ -19,8 +35,7 @@ chrome.action.onClicked.addListener(async (tab) => {
     } catch (error) {
         console.warn('Unsupported page for extension action: invalid or missing URL.', {
             tabId,
-            url,
-            error
+            url: sanitizeUrl(url)
         });
         return;
     }
@@ -28,7 +43,7 @@ chrome.action.onClicked.addListener(async (tab) => {
     if (!tabId || (protocol !== 'http:' && protocol !== 'https:')) {
         console.warn('Unsupported page for extension action: only http/https tabs with valid IDs are supported.', {
             tabId,
-            url,
+            url: sanitizeUrl(url),
             protocol
         });
         return;
@@ -53,7 +68,7 @@ chrome.action.onClicked.addListener(async (tab) => {
             }
         });
     } catch (error) {
-        console.error("Error injecting content script:", error);
+        console.error("Error injecting content script into " + sanitizeUrl(url) + ":", error.message || error);
     }
 });
 

--- a/content.js
+++ b/content.js
@@ -1,4 +1,20 @@
 // content.js - Content script that runs on demand
+
+/**
+ * Sanitizes a URL by removing query parameters and fragments to prevent sensitive data exposure.
+ * @param {string} url The URL to sanitize.
+ * @returns {string} The sanitized URL.
+ */
+function sanitizeUrl(url) {
+    if (!url) return '';
+    try {
+        const parsed = new URL(url);
+        return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+    } catch (e) {
+        return '[INVALID URL]';
+    }
+}
+
 console.log("Content script successfully injected and running.");
 
 function findDate(dateString) {
@@ -148,7 +164,8 @@ function processStructuredData(data, results) {
 }
 
 // This function will be executed when the extension icon is clicked
-window.findTimestamps = async function () {
+if (typeof window !== 'undefined') {
+    window.findTimestamps = async function () {
     let modifiedTimestamp = null, publishedTimestamp = null;
     let modifiedSource = null, publishedSource = null;
 
@@ -299,12 +316,13 @@ window.findTimestamps = async function () {
                 }
             }
         } catch (error) {
-            console.error('Error checking HTTP headers:', error);
+            console.error('Error checking HTTP headers for ' + sanitizeUrl(window.location.href) + ':', error.message || error);
         }
     }
 
-    await displayTimestamps(overlay, publishedTimestamp, publishedSource, modifiedTimestamp, modifiedSource);
-};
+        await displayTimestamps(overlay, publishedTimestamp, publishedSource, modifiedTimestamp, modifiedSource);
+    };
+}
 
 function removeOverlay(overlayElement) {
     setTimeout(() => {
@@ -366,6 +384,7 @@ async function displayTimestamp(pubDate, pubSource, modDate, modSource, overlayE
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
+        sanitizeUrl,
         formatDate,
         findStructuredData,
         processStructuredData,

--- a/tests/logging_sanitization.test.js
+++ b/tests/logging_sanitization.test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment node
+ */
+const { sanitizeUrl } = require('../content.js');
+
+describe('URL Sanitization', () => {
+    test('should remove query parameters', () => {
+        const url = 'https://example.com/page?query=secret&token=123';
+        expect(sanitizeUrl(url)).toBe('https://example.com/page');
+    });
+
+    test('should remove fragments', () => {
+        const url = 'https://example.com/page#section1';
+        expect(sanitizeUrl(url)).toBe('https://example.com/page');
+    });
+
+    test('should remove both query parameters and fragments', () => {
+        const url = 'https://example.com/page?query=secret#section1';
+        expect(sanitizeUrl(url)).toBe('https://example.com/page');
+    });
+
+    test('should handle URLs with no query or fragment', () => {
+        const url = 'https://example.com/page';
+        expect(sanitizeUrl(url)).toBe('https://example.com/page');
+    });
+
+    test('should handle root URLs', () => {
+        const url = 'https://example.com/';
+        expect(sanitizeUrl(url)).toBe('https://example.com/');
+    });
+
+    test('should handle invalid URLs', () => {
+        const url = 'not-a-url';
+        expect(sanitizeUrl(url)).toBe('[INVALID URL]');
+    });
+
+    test('should handle empty, null, or undefined input', () => {
+        expect(sanitizeUrl('')).toBe('');
+        expect(sanitizeUrl(null)).toBe('');
+        expect(sanitizeUrl(undefined)).toBe('');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the exposure of sensitive data (like authentication tokens or personally identifiable information) within console logs by logging raw URLs and full error objects that might contain such information.

⚠️ **Risk:** The potential impact if left unfixed is that an attacker with access to the browser console (or via other log-reading mechanisms) could extract sensitive credentials or user data from the logs.

🛡️ **Solution:** The fix implements a `sanitizeUrl` function using the `URL` API to extract only the protocol, host, and pathname, effectively stripping sensitive query strings and hashes. This function is now applied to all identified logging sites. Furthermore, `console.error` calls were updated to log only the error message instead of the entire error object, which prevents the leakage of unsanitized URLs via stack traces generated by the `URL` constructor.

---
*PR created automatically by Jules for task [12757917062502649791](https://jules.google.com/task/12757917062502649791) started by @BrandonML*