### PR TITLE
fix(content): fallback to dateCreated in schema.org structured data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tired of hunting around for when a webpage was published or last updated? This [
 
 We intelligently scan the webpage for both **published** and **modified** timestamps, checking various locations where a date might be hiding. Our approach follows a logical sequence, prioritizing the most reliable sources first:
 
-1.  **Schema.org Structured Data:** First, we analyze any [Schema.org](https://schema.org/) structured data (in JSON-LD or microdata format) embedded in the page. This often contains the most accurate `datePublished` and `dateModified` properties directly from the author. Content is securely sanitized to handle malformed control characters.
+1.  **Schema.org Structured Data:** First, we analyze any [Schema.org](https://schema.org/) structured data (in JSON-LD or microdata format) embedded in the page. This often contains the most accurate `datePublished` (or `dateCreated` as a fallback) and `dateModified` properties directly from the author. Content is securely sanitized to handle malformed control characters.
 2.  **Meta Tags:** Next, we look for direct indicators in the page's meta tags. This includes standard tags like `<meta name="last-modified" ...>` as well as [Open Graph (OG)](https://ogp.me/) tags like `og:updated_time` (for modified) and `og:published_time` (for published).
 3.  **HTML Content Patterns:** If the above checks don't yield a result, we start looking at the visible content of the page. We search for HTML5 `<time>` elements and common phrases or CSS classes (like `.post-date` or `.updated`) that often indicate dates.
 4.  **URL Patterns:** If a publication date still hasn't been found, we scan the website's address (URL) for common date patterns (like `/2023/10/15/`) often used by blogs and news sites.

--- a/content.js
+++ b/content.js
@@ -107,7 +107,7 @@ async function formatDate(dateString, preFetchedSettings = null) {
 
 function findStructuredData() {
     const scripts = document.querySelectorAll('script[type="application/ld+json"]');
-    let results = { modified: null, published: null, type: null };
+    let results = { modified: null, published: null, created: null, type: null };
     for (const script of scripts) {
         try {
             // Sanitize script content by replacing unescaped control characters (ASCII 0-31) with spaces
@@ -115,10 +115,13 @@ function findStructuredData() {
             const sanitizedContent = script.textContent.replace(/[\u0000-\u001F]/g, ' ');
             const data = JSON.parse(sanitizedContent);
             processStructuredData(data, results);
-            if (results.modified && results.published) break;
+            if (results.modified && (results.published || results.created)) break;
         } catch (e) {
             console.error('Error parsing structured data:', e);
         }
+    }
+    if (!results.published && results.created) {
+        results.published = results.created;
     }
     return results.modified || results.published ? results : null;
 }
@@ -140,6 +143,9 @@ function processStructuredData(data, results) {
         }
         if (data.datePublished && !results.published) {
             results.published = data.datePublished;
+        }
+        if (data.dateCreated && !results.created) {
+            results.created = data.dateCreated;
         }
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Page Timestamp Finder",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Finds and displays the published and modified/updated timestamp of a webpage",
     "permissions": [
         "activeTab",

--- a/onboarding.html
+++ b/onboarding.html
@@ -417,7 +417,7 @@
                             <h3>Schema.org Structured Data</h3>
                             <p>First, we analyze any <a href="https://schema.org/" target="_blank" rel="noopener noreferrer">Schema.org</a>
                                 structured data (in JSON-LD or microdata format) embedded in the page. This often
-                                contains the most accurate <code>datePublished</code> and <code>dateModified</code>
+                                contains the most accurate <code>datePublished</code> (or <code>dateCreated</code> as a fallback) and <code>dateModified</code>
                                 properties directly from the author. Content is securely sanitized to handle malformed
                                 control characters.</p>
                         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.0.0",
+      "version": "1.2.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "> <strong>Published in [Chrome Web Store](https://chromewebstore.google.com/detail/last-modified-timestamp/ilahbmmcmhcpjpfcgodgijbjadadicmg?pli=1)</strong>: 4/7/2025. >  > <strong>v1.0.2 Released</strong>: 8/1/2025.",
   "main": "background.js",
   "scripts": {

--- a/tests/date_extraction.test.js
+++ b/tests/date_extraction.test.js
@@ -190,7 +190,7 @@ describe('Priority Hierarchy Validation', () => {
     });
 
     test('processStructuredData correctly handles nested JSON objects', () => {
-        const results = { modified: null, published: null };
+        const results = { modified: null, published: null, created: null };
         const data = {
             "@context": "https://schema.org",
             "@graph": [
@@ -208,6 +208,51 @@ describe('Priority Hierarchy Validation', () => {
         contentModule.processStructuredData(data, results);
         expect(results.published).toBe("2023-01-01T00:00:00Z");
         expect(results.modified).toBe("2023-01-02T00:00:00Z");
+    });
+
+    test('findStructuredData uses dateCreated if datePublished is missing', async () => {
+        document.head.innerHTML = `
+            <script type="application/ld+json">
+                {
+                    "@context": "https://schema.org",
+                    "@type": "QAPage",
+                    "dateCreated": "2026-05-11T18:54:24.404Z",
+                    "dateModified": "2026-05-12T18:54:24.404Z"
+                }
+            </script>
+        `;
+
+        await window.findTimestamps();
+
+        expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                published: "2026-05-11T18:54:24.404Z",
+                modified: "2026-05-12T18:54:24.404Z"
+            })
+        );
+    });
+
+    test('findStructuredData prioritizes datePublished over dateCreated', async () => {
+        document.head.innerHTML = `
+            <script type="application/ld+json">
+                {
+                    "@context": "https://schema.org",
+                    "@type": "Article",
+                    "datePublished": "2025-01-01T00:00:00Z",
+                    "dateCreated": "2024-01-01T00:00:00Z",
+                    "dateModified": "2025-01-02T00:00:00Z"
+                }
+            </script>
+        `;
+
+        await window.findTimestamps();
+
+        expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                published: "2025-01-01T00:00:00Z",
+                modified: "2025-01-02T00:00:00Z"
+            })
+        );
     });
 
     test('HTTP header fallback catches network errors without crashing', async () => {


### PR DESCRIPTION
Updates `findStructuredData` and `processStructuredData` to properly extract the `dateCreated` field from JSON-LD schema objects (like QAPage). Uses `dateCreated` as a fallback for the publication date if `datePublished` is not found, maintaining priority for `datePublished`. Adds appropriate test coverage.

---
*PR created automatically by Jules for task [7712537872708518978](https://jules.google.com/task/7712537872708518978) started by @BrandonML*