### PR TITLE
Fix JSON-LD structured data timestamp attribution and exclude irrelevant schemas

### DIFF
--- a/content.js
+++ b/content.js
@@ -126,35 +126,35 @@ function findStructuredData() {
     return results.modified || results.published ? results : null;
 }
 
-function processStructuredData(data, results) {
+function processStructuredData(data, results, parentType = null) {
     if (Array.isArray(data)) {
         for (const item of data) {
-            processStructuredData(item, results);
+            processStructuredData(item, results, parentType);
         }
         return;
     }
     if (!data || typeof data !== 'object') return;
 
-    let currentType = null;
+    let currentType = parentType;
     if (data['@type']) {
         currentType = Array.isArray(data['@type']) ? data['@type'][0] : data['@type'];
         const typeLower = typeof currentType === 'string' ? currentType.toLowerCase() : '';
         if (['review', 'userreview', 'comment', 'usercomments'].includes(typeLower)) {
             return;
         }
+    }
 
-        if (data.dateModified && !results.modified) {
-            results.modified = data.dateModified;
-            results.modifiedType = currentType;
-        }
-        if (data.datePublished && !results.published) {
-            results.published = data.datePublished;
-            results.publishedType = currentType;
-        }
-        if (data.dateCreated && !results.created) {
-            results.created = data.dateCreated;
-            results.createdType = currentType;
-        }
+    if (data.dateModified && !results.modified) {
+        results.modified = data.dateModified;
+        results.modifiedType = currentType;
+    }
+    if (data.datePublished && !results.published) {
+        results.published = data.datePublished;
+        results.publishedType = currentType;
+    }
+    if (data.dateCreated && !results.created) {
+        results.created = data.dateCreated;
+        results.createdType = currentType;
     }
 
     for (const key in data) {
@@ -164,7 +164,7 @@ function processStructuredData(data, results) {
         }
 
         if (typeof data[key] === 'object' && data[key] !== null) {
-            processStructuredData(data[key], results);
+            processStructuredData(data[key], results, currentType);
         }
     }
 }
@@ -208,11 +208,11 @@ window.findTimestamps = async function () {
     if (structuredData) {
         if (structuredData.modified) {
             modifiedTimestamp = structuredData.modified;
-            modifiedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.modifiedType || 'Unknown'})`;
+            modifiedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.modifiedType || chrome.i18n.getMessage("unknownSchema") || 'Unknown'})`;
         }
         if (structuredData.published) {
             publishedTimestamp = structuredData.published;
-            publishedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.publishedType || 'Unknown'})`;
+            publishedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.publishedType || chrome.i18n.getMessage("unknownSchema") || 'Unknown'})`;
         }
     }
 

--- a/content.js
+++ b/content.js
@@ -107,7 +107,7 @@ async function formatDate(dateString, preFetchedSettings = null) {
 
 function findStructuredData() {
     const scripts = document.querySelectorAll('script[type="application/ld+json"]');
-    let results = { modified: null, published: null, created: null, type: null };
+    let results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
     for (const script of scripts) {
         try {
             // Sanitize script content by replacing unescaped control characters (ASCII 0-31) with spaces
@@ -135,21 +135,34 @@ function processStructuredData(data, results) {
     }
     if (!data || typeof data !== 'object') return;
 
+    let currentType = null;
     if (data['@type']) {
-        const type = Array.isArray(data['@type']) ? data['@type'][0] : data['@type'];
-        if (!results.type) results.type = type;
+        currentType = Array.isArray(data['@type']) ? data['@type'][0] : data['@type'];
+        const typeLower = typeof currentType === 'string' ? currentType.toLowerCase() : '';
+        if (['review', 'userreview', 'comment', 'usercomments'].includes(typeLower)) {
+            return;
+        }
+
         if (data.dateModified && !results.modified) {
             results.modified = data.dateModified;
+            results.modifiedType = currentType;
         }
         if (data.datePublished && !results.published) {
             results.published = data.datePublished;
+            results.publishedType = currentType;
         }
         if (data.dateCreated && !results.created) {
             results.created = data.dateCreated;
+            results.createdType = currentType;
         }
     }
 
     for (const key in data) {
+        const keyLower = key.toLowerCase();
+        if (['review', 'reviews', 'comment', 'comments'].includes(keyLower)) {
+            continue;
+        }
+
         if (typeof data[key] === 'object' && data[key] !== null) {
             processStructuredData(data[key], results);
         }
@@ -195,11 +208,11 @@ window.findTimestamps = async function () {
     if (structuredData) {
         if (structuredData.modified) {
             modifiedTimestamp = structuredData.modified;
-            modifiedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.type})`;
+            modifiedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.modifiedType || 'Unknown'})`;
         }
         if (structuredData.published) {
             publishedTimestamp = structuredData.published;
-            publishedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.type})`;
+            publishedSource = `${chrome.i18n.getMessage("sourceSchema")} (${structuredData.publishedType || 'Unknown'})`;
         }
     }
 

--- a/tests/date_extraction.test.js
+++ b/tests/date_extraction.test.js
@@ -195,7 +195,7 @@ describe('Priority Hierarchy Validation', () => {
     });
 
     test('processStructuredData correctly handles nested JSON objects', () => {
-        const results = { modified: null, published: null, created: null };
+        const results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
         const data = {
             "@context": "https://schema.org",
             "@graph": [
@@ -212,7 +212,58 @@ describe('Priority Hierarchy Validation', () => {
 
         contentModule.processStructuredData(data, results);
         expect(results.published).toBe("2023-01-01T00:00:00Z");
+        expect(results.publishedType).toBe("WebPage");
         expect(results.modified).toBe("2023-01-02T00:00:00Z");
+        expect(results.modifiedType).toBe("Article");
+    });
+
+    test('processStructuredData ignores excluded types and keys (Review, Comment)', () => {
+        const results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
+        const data = {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "datePublished": "2023-01-01T00:00:00Z", // Valid published date
+            "review": {
+                "@type": "Review",
+                "datePublished": "2024-01-01T00:00:00Z" // Should be ignored because of 'review' key
+            },
+            "comments": [
+                {
+                    "@type": "UserComments",
+                    "dateModified": "2024-02-01T00:00:00Z" // Should be ignored because of 'comments' key and UserComments type
+                }
+            ],
+            "nested": {
+                "@type": "Comment",
+                "dateModified": "2024-03-01T00:00:00Z" // Should be ignored because of 'Comment' type
+            }
+        };
+
+        contentModule.processStructuredData(data, results);
+        expect(results.published).toBe("2023-01-01T00:00:00Z");
+        expect(results.publishedType).toBe("Product");
+        expect(results.modified).toBe(null); // The modified dates were all in excluded blocks
+        expect(results.modifiedType).toBe(null);
+    });
+
+    test('processStructuredData correctly attributes nested timestamps to their local @type', () => {
+        const results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
+        const data = {
+            "@context": "https://schema.org",
+            "@type": "Organization", // Irrelevant top-level type
+            "name": "Acme Corp",
+            "hasPart": {
+                "@type": "Article",
+                "datePublished": "2023-01-01T00:00:00Z",
+                "dateModified": "2023-01-02T00:00:00Z"
+            }
+        };
+
+        contentModule.processStructuredData(data, results);
+        expect(results.published).toBe("2023-01-01T00:00:00Z");
+        expect(results.publishedType).toBe("Article");
+        expect(results.modified).toBe("2023-01-02T00:00:00Z");
+        expect(results.modifiedType).toBe("Article");
     });
 
     test('findStructuredData uses dateCreated if datePublished is missing', async () => {

--- a/tests/date_extraction.test.js
+++ b/tests/date_extraction.test.js
@@ -217,6 +217,22 @@ describe('Priority Hierarchy Validation', () => {
         expect(results.modifiedType).toBe("Article");
     });
 
+    test('processStructuredData attributes untyped nested timestamps to their parent @type', () => {
+        const results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
+        const data = {
+            "@context": "https://schema.org",
+            "@type": "QAPage",
+            "mainEntity": {
+                // Notice there is no @type here
+                "datePublished": "2023-05-01T00:00:00Z"
+            }
+        };
+
+        contentModule.processStructuredData(data, results);
+        expect(results.published).toBe("2023-05-01T00:00:00Z");
+        expect(results.publishedType).toBe("QAPage"); // Inherited from the parent QAPage
+    });
+
     test('processStructuredData ignores excluded types and keys (Review, Comment)', () => {
         const results = { modified: null, published: null, created: null, modifiedType: null, publishedType: null, createdType: null };
         const data = {


### PR DESCRIPTION
This PR fixes two bugs with how timestamps from JSON-LD Schema.org data were extracted and displayed:
1.  **Greedy Type Attribution:** The type of the very first object in the schema graph was assigned as the type for all extracted dates. This is now fixed by locally tracking `modifiedType`, `publishedType`, and `createdType` when the actual date string is discovered.
2.  **Irrelevant Timestamps:** Dates found inside `Review` or `Comment` schemas were incorrectly being surfaced as the page's main publish or modified dates. These nodes (and their corresponding object keys) are now explicitly ignored in `processStructuredData`.

---
*PR created automatically by Jules for task [12579435536050186499](https://jules.google.com/task/12579435536050186499) started by @BrandonML*