### PR TITLE
🧹 [chore] centralize removeOverlay logic

### DIFF
--- a/content.js
+++ b/content.js
@@ -378,8 +378,8 @@ async function displayTimestamps(overlayElement, publishedTimestamp, publishedSo
         overlayElement.textContent = chrome.i18n.getMessage("noTimestampFound") || "No reliable timestamp found";
         overlayElement.style.backgroundColor = 'rgba(244, 67, 54, 0.9)';
         chrome.runtime.sendMessage({ published: null, modified: null });
-        removeOverlay(overlayElement);
     }
+    removeOverlay(overlayElement);
 }
 
 async function displayTimestamp(pubDate, pubSource, modDate, modSource, overlayElement, settings = null) {
@@ -414,8 +414,6 @@ async function displayTimestamp(pubDate, pubSource, modDate, modSource, overlayE
 
     overlayElement.style.backgroundColor = 'rgba(33, 150, 243, 0.9)';
     chrome.runtime.sendMessage({ published: pubDate, modified: modDate });
-
-    removeOverlay(overlayElement);
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
🎯 **What:** Removed duplicated `removeOverlay(overlayElement)` calls. Centralized the logic to a single call at the end of the `displayTimestamps` function in `content.js`.
💡 **Why:** Centralizing the logic reduces duplicated code, making it cleaner, more consistent, and easier to maintain.
✅ **Verification:** Ran the full Jest test suite, which passed successfully (31/31 passing tests), confirming no regressions or changes to existing behavior.
✨ **Result:** Improved codebase maintainability and readability without altering the extension's behavior.

---
*PR created automatically by Jules for task [152117647124778515](https://jules.google.com/task/152117647124778515) started by @BrandonML*